### PR TITLE
Add comment syntax to the major mode definition

### DIFF
--- a/emacs/netlogo-mode.el
+++ b/emacs/netlogo-mode.el
@@ -107,6 +107,9 @@ netlogo-mode-syntax-table)
 ;; code for syntax highlighting
 (setq font-lock-defaults '((netlogo-font-lock-keywords)))
 
+(setq-local comment-start ";;")
+(setq-local comment-end "")
+
 ;;(set (make-local-variable 'font-lock-defaults) '(netlogo-font-lock-keywords))
 ;;(set (make-local-variable 'indent-line-function) 'netlogo-indent-line)
 


### PR DESCRIPTION
This lets comment-dwim and related modes automatically pick up the right comment
syntax.
